### PR TITLE
filetype check through shebang

### DIFF
--- a/ftdetect/applescript.vim
+++ b/ftdetect/applescript.vim
@@ -1,12 +1,20 @@
 "Plugin Name: AppleScript
 "Author: mityu
-"Last Change: 04-Mar-2017.
+"Modified: idrisr
+"Last Change: 14-Jan-2022.
 
 let s:cpo_save=&cpo
 set cpo&vim
 
 au BufNewFile,BufRead *.scpt setf applescript
 au BufNewFile,BufRead *.applescript setf applescript
+au BufNewFile,BufRead * call s:checkshebang()
+
+function s:checkshebang()
+    if !did_filetype() && getline(1) =~ '^#!.*osascript$'
+        setfiletype applescript
+    endif
+endfunction
 
 let &cpo=s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
This PR allows the plugin to read the shebang file of a script, and if the shebang line includes `osascript`, it will set the filetype to `applescript`.